### PR TITLE
Code cleanups

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -5,18 +5,18 @@
 using namespace std;
 using boost::asio::ip::tcp;
 
-Camera::Camera(std::string name, std::string ip_address, uint8_t default_preset, boost::asio::io_service &io_service)
-    : _name(name),
-      _address(ip_address),
-      _default_preset(default_preset),
-      _io_service(io_service),
-      _socket(_io_service)
+Camera::Camera(const CameraDetails &details, boost::asio::io_service &io_service)
+        : _name(details.name),
+          _address(details.ip_address),
+          _default_preset(details.default_preset),
+          _io_service(io_service),
+          _socket(_io_service)
 {
-    cout << "Connecting to camera " << name << " (" << ip_address << ")..." << endl;
+    cout << "Connecting to camera " << _name << " (" << _address << ")..." << endl;
 
     try {
-        tcp_connect_with_timeout(ip_address, "5678", boost::posix_time::milliseconds(10));
-        cout << "Connected to camera " << name << "!" << endl;
+        tcp_connect_with_timeout(_address, "5678", boost::posix_time::milliseconds(10));
+        cout << "Connected to camera " << _name << "!" << endl;
     } catch(const boost::system::system_error &e) {
         if(e.code() == boost::asio::error::operation_aborted) {
             cerr << "ERROR: Connecting to camera " << _name << " timed out." << endl;

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -10,6 +10,8 @@ class Camera {
 public:
     Camera(const CameraDetails &details, boost::asio::io_service &io_service);
 
+    Camera(Camera &&other) = default;
+
     ~Camera();
 
     void save_preset(uint8_t number);

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -56,10 +56,6 @@ public:
         return _name;
     }
 
-    inline std::string address() const {
-	return _address;
-    }
-
     static inline uint8_t pan_max() {
         return 24;
     }

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -4,10 +4,11 @@
 #include <cstdint>
 #include <vector>
 #include <boost/asio.hpp>
+#include "Configuration.h"
 
 class Camera {
 public:
-    Camera(std::string name, std::string ip_address, uint8_t default_preset, boost::asio::io_service &io_service);
+    Camera(const CameraDetails &details, boost::asio::io_service &io_service);
 
     ~Camera();
 

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -80,14 +80,6 @@ void Controller::axis_control() {
     _prev_hat = hat_state;
 }
 
-Joystick& Controller::joystick() {
-    return _joystick;
-}
-
-Camera& Controller::camera() {
-    return _camera;
-}
-
 void Controller::button_control() {
     if (_joystick.button(1) && !_prev_button[1]) {
         cout << "*** reinit camera: " << _camera.name() << "\n";

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -9,6 +9,8 @@ Controller::Controller(Joystick&& joystick, Camera&& camera)
     : _joystick(std::move(joystick)),
       _camera(std::move(camera))
 {
+    _joystick.set_deadzone(0, 0.25);
+    _joystick.set_deadzone(1, 0.25);
 }
 
 void Controller::update() {

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -5,37 +5,27 @@
 
 using namespace std;
 
-Controller::Controller(std::shared_ptr<Joystick> joystick, std::shared_ptr<Camera> camera)
-    : _joystick(joystick),
-      _camera(camera)
+Controller::Controller(Joystick&& joystick, Camera&& camera)
+    : _joystick(std::move(joystick)),
+      _camera(std::move(camera))
 {
 }
 
 void Controller::update() {
-    if(_joystick != nullptr && _camera != nullptr) {
-        _joystick->update();
+    _joystick.update();
 
-        axis_control();
+    axis_control();
 
-        button_control();
+    button_control();
 
-        set_prev_buttons();
-    }
-}
-
-void Controller::change_joystick(std::shared_ptr<Joystick> joystick) {
-    _joystick = joystick;
-}
-
-void Controller::chage_camera(std::shared_ptr<Camera> camera) {
-    _camera = camera;
+    set_prev_buttons();
 }
 
 void Controller::axis_control() {
-    auto pan = _joystick->axis(0);
-    auto tilt = _joystick->axis(1);
+    auto pan = _joystick.axis(0);
+    auto tilt = _joystick.axis(1);
 
-    auto speed = ((-1.0 * _joystick->axis(3)) + 1.0) / 2.0;
+    auto speed = ((-1.0 * _joystick.axis(3)) + 1.0) / 2.0;
 
     if(pan != _prev_pan || tilt != _prev_tilt || speed != _prev_speed) {
         Camera::RotateType type;
@@ -66,114 +56,114 @@ void Controller::axis_control() {
             }
         }
 
-        _camera->rotate(type, speed);
+        _camera.rotate(type, speed);
     }
 
     _prev_pan = pan;
     _prev_tilt = tilt;
     _prev_speed = speed;
 
-    auto hat_state =_joystick->hat(0);
+    auto hat_state =_joystick.hat(0);
 
     if(hat_state != _prev_hat) {
         if (static_cast<int>(hat_state & Joystick::HatDirection::UP) > 0) {
-            _camera->zoom(Camera::ZoomType::TELE);
+            _camera.zoom(Camera::ZoomType::TELE);
         } else if (static_cast<int>(hat_state & Joystick::HatDirection::DOWN) > 0) {
-            _camera->zoom(Camera::ZoomType::WIDE);
+            _camera.zoom(Camera::ZoomType::WIDE);
         } else {
-            _camera->zoom(Camera::ZoomType::STOP);
+            _camera.zoom(Camera::ZoomType::STOP);
         }
     }
 
     _prev_hat = hat_state;
 }
 
-std::shared_ptr<Joystick> Controller::joystick() const {
+Joystick& Controller::joystick() {
     return _joystick;
 }
 
-std::shared_ptr<Camera> Controller::camera() const {
+Camera& Controller::camera() {
     return _camera;
 }
 
 void Controller::button_control() {
-    if (_joystick->button(1) && !_prev_button[1]) {
-        cout << "*** reinit camera: " << _camera->name() << "\n";
-        _camera->reconnect();
-        cout << "*** reinit camera: " << _camera->name() << " complete!\n";
+    if (_joystick.button(1) && !_prev_button[1]) {
+        cout << "*** reinit camera: " << _camera.name() << "\n";
+        _camera.reconnect();
+        cout << "*** reinit camera: " << _camera.name() << " complete!\n";
 	return;
     }
 
     // Emergency stop button
-    if(_joystick->button(0) && !_prev_button[0]){
-        _camera->stop();
-        cout << setw(12) << _camera->name() << "\tStop\n";
+    if(_joystick.button(0) && !_prev_button[0]){
+        _camera.stop();
+        cout << setw(12) << _camera.name() << "\tStop\n";
     }
 
     // Go to a preset (button pressed down)
-    if (_joystick->button(3)) {
-        if(_joystick->button(2) && !_prev_button[2]) {
-            _camera->save_preset(0);
-            cout << setw(12) << _camera->name() << "\tSaving preset 0\n";
-        } else if(_joystick->button(4) && !_prev_button[4]) {
-            _camera->save_preset(2);
-            cout << setw(12) << _camera->name() << "\tSaving preset 2\n";
-        } else if(_joystick->button(5) && !_prev_button[5]) {
-            _camera->save_preset(3);
-            cout << setw(12) << _camera->name() << "\tSaving preset 3\n";
-        } else if(_joystick->button(6) && !_prev_button[6]){
-            _camera->save_preset(4);
-            cout << setw(12) << _camera->name() << "\tSaving preset 4\n";
-        } else if(_joystick->button(7) && !_prev_button[7]){
-            _camera->save_preset(5);
-            cout << setw(12) << _camera->name() << "\tSaving preset 5\n";
-        } else if(_joystick->button(8) && !_prev_button[8]){
-            _camera->save_preset(6);
-            cout << setw(12) << _camera->name() << "\tSaving preset 6\n";
-        } else if(_joystick->button(9) && !_prev_button[9]){
-            _camera->save_preset(7);
-            cout << setw(12) << _camera->name() << "\tSaving preset 7\n";
-        } else if(_joystick->button(10) && !_prev_button[10]){
-            _camera->save_preset(8);
-            cout << setw(12) << _camera->name() << "\tSaving preset 8\n";
-        } else if(_joystick->button(11) && !_prev_button[11]){
-            _camera->save_preset(9);
-            cout << setw(12) << _camera->name() << "\tSaving preset 9\n";
+    if (_joystick.button(3)) {
+        if(_joystick.button(2) && !_prev_button[2]) {
+            _camera.save_preset(0);
+            cout << setw(12) << _camera.name() << "\tSaving preset 0\n";
+        } else if(_joystick.button(4) && !_prev_button[4]) {
+            _camera.save_preset(2);
+            cout << setw(12) << _camera.name() << "\tSaving preset 2\n";
+        } else if(_joystick.button(5) && !_prev_button[5]) {
+            _camera.save_preset(3);
+            cout << setw(12) << _camera.name() << "\tSaving preset 3\n";
+        } else if(_joystick.button(6) && !_prev_button[6]){
+            _camera.save_preset(4);
+            cout << setw(12) << _camera.name() << "\tSaving preset 4\n";
+        } else if(_joystick.button(7) && !_prev_button[7]){
+            _camera.save_preset(5);
+            cout << setw(12) << _camera.name() << "\tSaving preset 5\n";
+        } else if(_joystick.button(8) && !_prev_button[8]){
+            _camera.save_preset(6);
+            cout << setw(12) << _camera.name() << "\tSaving preset 6\n";
+        } else if(_joystick.button(9) && !_prev_button[9]){
+            _camera.save_preset(7);
+            cout << setw(12) << _camera.name() << "\tSaving preset 7\n";
+        } else if(_joystick.button(10) && !_prev_button[10]){
+            _camera.save_preset(8);
+            cout << setw(12) << _camera.name() << "\tSaving preset 8\n";
+        } else if(_joystick.button(11) && !_prev_button[11]){
+            _camera.save_preset(9);
+            cout << setw(12) << _camera.name() << "\tSaving preset 9\n";
         }
     } else {
-        if(_joystick->button(2) && !_prev_button[2]) {
-            _camera->recall_preset(0);
-            cout << setw(12) << _camera->name() << "\tRecalling preset 0\n";
-        } else if(_joystick->button(4) && !_prev_button[4]) {
-            _camera->recall_preset(2);
-            cout << setw(12) << _camera->name() << "\tRecalling preset 2\n";
-        } else if(_joystick->button(5) && !_prev_button[5]) {
-            _camera->recall_preset(3);
-            cout << setw(12) << _camera->name() << "\tRecalling preset 3\n";
-        } else if(_joystick->button(6) && !_prev_button[6]){
-            _camera->recall_preset(4);
-            cout << setw(12) << _camera->name() << "\tRecalling preset 4\n";
-        } else if(_joystick->button(7) && !_prev_button[7]){
-            _camera->recall_preset(5);
-            cout << setw(12) << _camera->name() << "\tRecalling preset 5\n";
-        } else if(_joystick->button(8) && !_prev_button[8]){
-            _camera->recall_preset(6);
-            cout << setw(12) << _camera->name() << "\tRecalling preset 6\n";
-        } else if(_joystick->button(9) && !_prev_button[9]){
-            _camera->recall_preset(7);
-            cout << setw(12) << _camera->name() << "\tRecalling preset 7\n";
-        } else if(_joystick->button(10) && !_prev_button[10]){
-            _camera->recall_preset(8);
-            cout << setw(12) << _camera->name() << "\tRecalling preset 8\n";
-        } else if(_joystick->button(11) && !_prev_button[11]){
-            _camera->recall_preset(9);
-            cout << setw(12) << _camera->name() << "\tRecalling preset 9\n";
+        if(_joystick.button(2) && !_prev_button[2]) {
+            _camera.recall_preset(0);
+            cout << setw(12) << _camera.name() << "\tRecalling preset 0\n";
+        } else if(_joystick.button(4) && !_prev_button[4]) {
+            _camera.recall_preset(2);
+            cout << setw(12) << _camera.name() << "\tRecalling preset 2\n";
+        } else if(_joystick.button(5) && !_prev_button[5]) {
+            _camera.recall_preset(3);
+            cout << setw(12) << _camera.name() << "\tRecalling preset 3\n";
+        } else if(_joystick.button(6) && !_prev_button[6]){
+            _camera.recall_preset(4);
+            cout << setw(12) << _camera.name() << "\tRecalling preset 4\n";
+        } else if(_joystick.button(7) && !_prev_button[7]){
+            _camera.recall_preset(5);
+            cout << setw(12) << _camera.name() << "\tRecalling preset 5\n";
+        } else if(_joystick.button(8) && !_prev_button[8]){
+            _camera.recall_preset(6);
+            cout << setw(12) << _camera.name() << "\tRecalling preset 6\n";
+        } else if(_joystick.button(9) && !_prev_button[9]){
+            _camera.recall_preset(7);
+            cout << setw(12) << _camera.name() << "\tRecalling preset 7\n";
+        } else if(_joystick.button(10) && !_prev_button[10]){
+            _camera.recall_preset(8);
+            cout << setw(12) << _camera.name() << "\tRecalling preset 8\n";
+        } else if(_joystick.button(11) && !_prev_button[11]){
+            _camera.recall_preset(9);
+            cout << setw(12) << _camera.name() << "\tRecalling preset 9\n";
         }
     }
 }
 
 void Controller::set_prev_buttons() {
     for(size_t i = 0; i < _prev_button.size(); ++i) {
-        _prev_button[i] = _joystick->button(i);
+        _prev_button[i] = _joystick.button(i);
     }
 }

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -6,22 +6,18 @@
 
 class Controller {
 public:
-    Controller(std::shared_ptr<Joystick> joystick = nullptr, std::shared_ptr<Camera> camera = nullptr);
+    Controller(Joystick&& joystick, Camera&& camera);
 
     void update();
 
-    void change_joystick(std::shared_ptr<Joystick> joystick);
+    Joystick& joystick();
 
-    void chage_camera(std::shared_ptr<Camera> camera);
-
-    std::shared_ptr<Joystick> joystick() const;
-
-    std::shared_ptr<Camera> camera() const;
+    Camera& camera();
 
 private:
-    std::shared_ptr<Joystick> _joystick;
+    Joystick _joystick;
 
-    std::shared_ptr<Camera> _camera;
+    Camera _camera;
 
     Joystick::HatDirection _prev_hat = Joystick::HatDirection::CENTERED;
     double _prev_pan = 0;

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -10,10 +10,6 @@ public:
 
     void update();
 
-    Joystick& joystick();
-
-    Camera& camera();
-
 private:
     Joystick _joystick;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,12 +53,12 @@ int main(){
 
     for(size_t i = 0; i < joystick_count && i < camera_details.size(); ++i) {
         cout << "Assigning joystick " << i << " to camera " << camera_details[i].name << "(" << camera_details[i].ip_address << ")." << endl;
-        controllers.emplace_back(make_shared<Joystick>(i), make_shared<Camera>(camera_details[i], io_service));
+        controllers.emplace_back(Joystick(i), Camera(camera_details[i], io_service));
     }
 
     for(auto &controller : controllers) {
-        controller.joystick()->set_deadzone(0, 0.25);
-        controller.joystick()->set_deadzone(1, 0.25);
+        controller.joystick().set_deadzone(0, 0.25);
+        controller.joystick().set_deadzone(1, 0.25);
     }
 
     auto t = chrono::system_clock::now();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,10 @@
-#include <signal.h>
+#include <csignal>
 #include <iostream>
 #include <chrono>
 #include <thread>
 #include "Joystick.h"
 #include "Camera.h"
 #include "Controller.h"
-#include "Configuration.h"
 
 using namespace std;
 
@@ -20,7 +19,7 @@ void set_SIGINT_handler() {
     sigIntHandler.sa_handler = signal_handler;
     sigemptyset(&sigIntHandler.sa_mask);
     sigIntHandler.sa_flags = 0;
-    sigaction(SIGINT, &sigIntHandler, NULL);
+    sigaction(SIGINT, &sigIntHandler, nullptr);
 }
 
 int main(){
@@ -37,11 +36,11 @@ int main(){
 
     boost::asio::io_service io_service;
 
-    size_t joystick_count = static_cast<size_t>(Joystick::NumberOfConnectJoysticks());
+    auto joystick_count = static_cast<size_t>(Joystick::NumberOfConnectJoysticks());
 
     cout << "Found " << joystick_count << " joysticks." << endl;
 
-    auto connection_count =  min(joystick_count, static_cast<size_t>(camera_details.size()));
+    auto connection_count =  min(joystick_count, camera_details.size());
 
     cout << "Conecting to " << connection_count << " cameras." << endl;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,7 @@ int main(){
 
     for(size_t i = 0; i < joystick_count && i < camera_details.size(); ++i) {
         cout << "Assigning joystick " << i << " to camera " << camera_details[i].name << "(" << camera_details[i].ip_address << ")." << endl;
-        controllers.emplace_back(make_shared<Joystick>(i), make_shared<Camera>(camera_details[i].name, camera_details[i].ip_address, camera_details[i].default_preset, io_service));
+        controllers.emplace_back(make_shared<Joystick>(i), make_shared<Camera>(camera_details[i], io_service));
     }
 
     for(auto &controller : controllers) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,11 +56,6 @@ int main(){
         controllers.emplace_back(Joystick(i), Camera(camera_details[i], io_service));
     }
 
-    for(auto &controller : controllers) {
-        controller.joystick().set_deadzone(0, 0.25);
-        controller.joystick().set_deadzone(1, 0.25);
-    }
-
     auto t = chrono::system_clock::now();
 
     while(running){


### PR DESCRIPTION
This PR cleans up some of the code in ways that will hopefully make the upcoming redesigns easier. 
The biggest change is the moving away from `std::shared_ptr` in favor of movable `Joystick` and `Camera` objects.