### PR TITLE
Change camera connection from tcp/5678 to udp/1259

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -3,7 +3,7 @@
 #include "Camera.h"
 
 using namespace std;
-using boost::asio::ip::tcp;
+using boost::asio::ip::udp;
 
 Camera::Camera(std::string name, std::string ip_address, uint8_t default_preset, boost::asio::io_service &io_service)
     : _name(name),
@@ -15,7 +15,7 @@ Camera::Camera(std::string name, std::string ip_address, uint8_t default_preset,
     cout << "Connecting to camera " << name << " (" << ip_address << ")..." << endl;
 
     try {
-        tcp_connect_with_timeout(ip_address, "5678", boost::posix_time::milliseconds(10));
+        udp_connect(ip_address, "1259");
         cout << "Connected to camera " << name << "!" << endl;
     } catch(const boost::system::system_error &e) {
         if(e.code() == boost::asio::error::operation_aborted) {
@@ -157,7 +157,7 @@ void Camera::reconnect() {
     }
 
     try {
-        tcp_connect_with_timeout(_address, "5678", boost::posix_time::milliseconds(10));
+        udp_connect(_address, "1259");
     } catch (const boost::system::system_error &e) {
         if (e.code() == boost::asio::error::operation_aborted) {
             cerr << "ERROR: Connection to camera " << _name << " timed out." << endl;
@@ -165,13 +165,9 @@ void Camera::reconnect() {
     } 
 }
 
-void Camera::tcp_connect_with_timeout(const std::string &host, const std::string &service,
-                                      boost::posix_time::time_duration timeout) {
-    tcp::resolver::query query{host, service};
-    tcp::resolver::iterator endpoint_iter = tcp::resolver{_io_service}.resolve(query);
-
-    boost::asio::deadline_timer timer{_io_service};
-    timer.expires_from_now(timeout);
+void Camera::udp_connect(const std::string &host, const std::string &service) {
+    udp::resolver::query query{host, service};
+    udp::resolver::iterator endpoint_iter = udp::resolver{_io_service}.resolve(query);
 
     boost::system::error_code ec = boost::asio::error::would_block;
 

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -77,12 +77,11 @@ private:
     uint8_t _default_preset;
 
     boost::asio::io_service& _io_service;
-    boost::asio::ip::tcp::socket _socket;
+    boost::asio::ip::udp::socket _socket;
 
     void send_command(std::vector<uint8_t> command);
 
-    void tcp_connect_with_timeout(const std::string& host, const std::string& service,
-                                  boost::posix_time::time_duration timeout);
+    void udp_connect(const std::string& host, const std::string& service);
 
 };
 


### PR DESCRIPTION
The PTZ Optics cameras support PTZ control not only over TCP at port 5678, but also over UDP at port 1259. The commands are the same and so the changes needed to switch to UDP are minimal. My hope is that this provides performance improvements.