### PR TITLE
Overriding Axis Control

### DIFF
--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -33,14 +33,12 @@ void Controller::chage_camera(std::shared_ptr<Camera> camera) {
 
 void Controller::attempt_axis_control() {
     // Emergency stop button
-    if(_joystick->button(0)){
+    if(_joystick->button(0) && !_prev_button[0]) {
         _camera->stop();
-        if (!_prev_button[0]) {
-            cout << setw(12) << _camera->name() << "\tStop\n";
-            _prev_pan = 0;
-            _prev_tilt = 0;
-            _prev_speed = 0;
-        }
+        cout << setw(12) << _camera->name() << "\tStop\n";
+        _prev_pan = 0;
+        _prev_tilt = 0;
+        _prev_speed = 0;
     } else {
         axis_control();
     }

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -33,12 +33,14 @@ void Controller::chage_camera(std::shared_ptr<Camera> camera) {
 
 void Controller::attempt_axis_control() {
     // Emergency stop button
-    if(_joystick->button(0) && !_prev_button[0]) {
-        _camera->stop();
-        cout << setw(12) << _camera->name() << "\tStop\n";
-        _prev_pan = 0;
-        _prev_tilt = 0;
-        _prev_speed = 0;
+    if(_joystick->button(0)){
+        if (!_prev_button[0]) {
+            _camera->stop();
+            cout << setw(12) << _camera->name() << "\tStop\n";
+            _prev_pan = 0;
+            _prev_tilt = 0;
+            _prev_speed = 0;
+        }
     } else {
         axis_control();
     }

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -15,7 +15,7 @@ void Controller::update() {
     if(_joystick != nullptr && _camera != nullptr) {
         _joystick->update();
 
-        axis_control();
+        attempt_axis_control();
 
         button_control();
 
@@ -29,6 +29,18 @@ void Controller::change_joystick(std::shared_ptr<Joystick> joystick) {
 
 void Controller::chage_camera(std::shared_ptr<Camera> camera) {
     _camera = camera;
+}
+
+void Controller::attempt_axis_control() {
+    // Emergency stop button
+    if(_joystick->button(0)){
+        _camera->stop();
+        if (!_prev_button[0]) {
+            cout << setw(12) << _camera->name() << "\tStop\n";
+        }
+    } else {
+        axis_control();
+    }
 }
 
 void Controller::axis_control() {
@@ -102,12 +114,6 @@ void Controller::button_control() {
         _camera->reconnect();
         cout << "*** reinit camera: " << _camera->name() << " complete!\n";
 	return;
-    }
-
-    // Emergency stop button
-    if(_joystick->button(0) && !_prev_button[0]){
-        _camera->stop();
-        cout << setw(12) << _camera->name() << "\tStop\n";
     }
 
     // Go to a preset (button pressed down)

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -37,6 +37,9 @@ void Controller::attempt_axis_control() {
         _camera->stop();
         if (!_prev_button[0]) {
             cout << setw(12) << _camera->name() << "\tStop\n";
+            _prev_pan = 0;
+            _prev_tilt = 0;
+            _prev_speed = 0;
         }
     } else {
         axis_control();

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -30,6 +30,8 @@ private:
 
     std::array<bool,12> _prev_button;
 
+    void attempt_axis_control();
+
     void axis_control();
 
     void button_control();


### PR DESCRIPTION
I added an extra method in Controller that checks the stop button before doing axis control. In the current configuration, the stop button sends a stop command once. If the controller moves at all while the button is held down, it will override the stop command, making it difficult to recenter the controller if it goes out of control. With this new check, pressing and holding the button should prevent the controller from moving the camera. 

I will be at the upcoming Columbus competition to test the code.